### PR TITLE
Added description and instructions parameters to transfer requests.

### DIFF
--- a/dts/client.py
+++ b/dts/client.py
@@ -289,15 +289,20 @@ Optional arguments:
                  file_ids = None,
                  source = None,
                  destination = None,
+                 description = None,
                  timeout = None):
         """
 `client.transfer(file_ids = None,
                  source = None,
                  destination = None,
+                 description = None,
                  timeout = None) -> UUID
 
 * Submits a request to transfer files from a source to a destination database. the
   files in the source database are identified by a list of string file_ids.
+Optional arguments:
+    * description: a string containing Markdown text describing the transfer
+      (helpful for providing instructions to process the payload at its destination)
 """
         if not self.uri:
             raise RuntimeError('dts.Client: not connected.')
@@ -314,6 +319,7 @@ Optional arguments:
                                      json={
                                          'source':      source,
                                          'destination': destination,
+                                         'description': description,
                                          'file_ids':    file_ids,
                                      },
                                      auth=self.auth,

--- a/dts/client.py
+++ b/dts/client.py
@@ -229,6 +229,62 @@ Optional arguments:
             return None
         return [JsonResource(r) for r in response.json()['resources']]
 
+    def fetch_metadata(self,
+               database = None,
+               ids = None,
+               offset = 0,
+               limit = None,
+    ):
+        """
+`client.fetch_metadata(database = None,
+               ids = None,
+               offset = 0,
+               limit = None) -> `list` of `frictionless.DataResource` objects
+
+* Fetches metadata for the files with the specified IDs within the specified
+  database.
+Optional arguments:
+    * offset: a 0-based index from which to start retrieving results (default: 0)
+    * limit: if given, the maximum number of results to retrieve
+"""
+        if not self.uri:
+            raise RuntimeError('dts.Client: not connected.')
+        if type(ids) != list or len(ids) == 0:
+            raise RuntimeError('search: missing or invalid file IDs.')
+        if type(database) != str:
+            raise TypeError('search: database must be a string.')
+        if type(offset) != int or offset < 0:
+            raise TypeError(f'search: invalid offset: {offset}.')
+        if limit:
+            if type(limit) != int:
+                raise TypeError('search: limit must be an int.')
+            elif limit < 1:
+                raise TypeError(f'search: invalid number of retrieved results: {N}')
+        try:
+            params = {
+                'database': database,
+                'ids':    ','.join(ids),
+            }
+            for name in ['offset', 'limit']:
+                val = eval(name)
+                if val:
+                    params[name] = val
+            response = requests.get(url=f'{self.uri}/files/by-id',
+                                    params=params,
+                                    auth=self.auth)
+            response.raise_for_status()
+        except HTTPError as http_err:
+            logger.error(f'HTTP error occurred: {http_err}')
+            return None
+        except requests.exceptions.HTTPError as err:
+            logger.error(f'HTTP error occurred: {err}')
+            return None
+        except Exception as err:
+            logger.error(f'Other error occurred: {err}')
+            return None
+        else:
+            return [JsonResource(r) for r in response.json()['resources']]
+
     def transfer(self,
                  file_ids = None,
                  source = None,

--- a/dts/client.py
+++ b/dts/client.py
@@ -296,13 +296,15 @@ Optional arguments:
                  source = None,
                  destination = None,
                  description = None,
+                 instructions = None,
                  timeout = None) -> UUID
 
 * Submits a request to transfer files from a source to a destination database. the
   files in the source database are identified by a list of string file_ids.
 Optional arguments:
     * description: a string containing Markdown text describing the transfer
-      (helpful for providing instructions to process the payload at its destination)
+    * instructions: a dict representing a JSON object containing instructions
+                    for processing the payload at its destination
 """
         if not self.uri:
             raise RuntimeError('dts.Client: not connected.')
@@ -314,14 +316,22 @@ Optional arguments:
             raise TypeError('transfer: file_ids must be a list of string file IDs.')
         if timeout and not isinstance(timeout, int) and not isinstance(timeout, float):
             raise TypeError('transfer: timeout must be a number of seconds.')
+        if description and not isinstance(description, str):
+            raise TypeError('transfer: description must be a string containing Markdown.')
+        if instructions and not isinstance(instructions, dict):
+            raise TypeError('transfer: instructions must be a dict representing a JSON object containing machine-readable instructions for processing the payload at its destination.')
+        json_obj = {
+            'source':      source,
+            'destination': destination,
+            'file_ids':    file_ids,
+        }
+        if description:
+            json_obj['description'] = description
+        if instructions:
+            json_obj['instructions'] = instructions
         try:
             response = requests.post(url=f'{self.uri}/transfers',
-                                     json={
-                                         'source':      source,
-                                         'destination': destination,
-                                         'description': description,
-                                         'file_ids':    file_ids,
-                                     },
+                                     json=json_obj,
                                      auth=self.auth,
                                      timeout=timeout)
             response.raise_for_status()


### PR DESCRIPTION
This lets us pass a string containing a Markdown description of a transfer to the DTS client. This description can be used to provide instructions for processing a payload at its destination, for example.

This should be merged after #4.