### PR TITLE
Use dependency groups to specify dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,13 @@ dependencies = [
 ]
 
 [tool.uv]
-dev-dependencies = [
-  # testing
-  "coverage >=7.6.3,<8",
+default-groups = ["test", "doc"]
 
-  # docs
+[dependency-groups]
+test = [
+  "coverage >=7.6.3,<8",
+]
+doc = [
   "mkdocs-material>=9.5.41",
   "mkdocs>=1.6.1",
   "mkdocstrings-python>=1.12.1",

--- a/uv.lock
+++ b/uv.lock
@@ -138,13 +138,15 @@ dependencies = [
     { name = "requests" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "coverage" },
+[package.dependency-groups]
+doc = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
+]
+test = [
+    { name = "coverage" },
 ]
 
 [package.metadata]
@@ -153,14 +155,14 @@ requires-dist = [
     { name = "requests", specifier = ">=2.32.3,<3" },
 ]
 
-[package.metadata.requires-dev]
-dev = [
-    { name = "coverage", specifier = ">=7.6.3,<8" },
+[package.metadata.dependency-groups]
+doc = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.5.41" },
     { name = "mkdocstrings", specifier = ">=0.26.2" },
     { name = "mkdocstrings-python", specifier = ">=1.12.1" },
 ]
+test = [{ name = "coverage", specifier = ">=7.6.3,<8" }]
 
 [[package]]
 name = "frictionless"


### PR DESCRIPTION
The just released [uv 0.4.27](https://github.com/astral-sh/uv/releases/tag/0.4.27) includes support for [PEP 735](https://peps.python.org/pep-0735/), which allows fixing what dependencies are used for each task as requested in https://github.com/kbase/dtspy/pull/10#issuecomment-2422979113