### PR TITLE
Adds an `orcid` parameter to the DTS client's `cancel` method.

### DIFF
--- a/dts/client.py
+++ b/dts/client.py
@@ -389,7 +389,8 @@ Raises:
         )
 
     def cancel_transfer(self: "Client",
-                        id: uuid.UUID) -> None:
+                        id: uuid.UUID,
+                        orcid: str) -> None:
         """Cancels a file transfer with the requested UUID.
 
 Status information for the cancelled transfer is retained for a time so its
@@ -397,6 +398,7 @@ cancellation can be seen.
 
 Args:
     id: A UUID that uniquely identifies the transfer operation to be cancelled.
+    orcid: The ORCID of the user that initiated the transfer.
 
 Raises:
     RuntimeError: Indicates an issue with the DTS client and its connection to the server.
@@ -406,7 +408,7 @@ Raises:
         if not self.uri:
             raise RuntimeError('dts.Client: not connected.')
         try:
-            response = requests.delete(url=f'{self.uri}/transfers/{id}',
+            response = requests.delete(url=f'{self.uri}/transfers/{id}?orcid={orcid}',
                                        auth=self.auth)
             response.raise_for_status()
         except HTTPError as http_err:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -12,7 +12,7 @@ class TestClient(unittest.TestCase):
         if not self.token:
             raise ValueError('Environment variable DTS_KBASE_DEV_TOKEN must be set!')
         self.orcid = os.getenv('DTS_KBASE_TEST_ORCID')
-        self.server = "https://lb-dts.staging.kbase.us"
+        self.server = "https://dts.kbase.us"
 
     def test_ctor(self):
         client = dts.Client(api_key = self.token, server = self.server)


### PR DESCRIPTION
This supports a more "secure" model for canceling transfers.